### PR TITLE
Removed focus from back to top button when hidden

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@
       if (hidden) { return }
       upEl.className = 'hidden'
       hidden = true
+      upEl.blur()
     }
 
     function appendElement () {


### PR DESCRIPTION
This is useful on touch devices when the back to top button has extra styling added for the hover,focus state. Eg, different background colour, opacity or shadow. Otherwise when the button is tapped on touch devices it keeps the hover/focus styling applied when shown again until something else is tapped.